### PR TITLE
Ensure that --configs-dir isn't set to anything useful in tests

### DIFF
--- a/yoconfigurator/tests/test_configurator.py
+++ b/yoconfigurator/tests/test_configurator.py
@@ -23,7 +23,8 @@ class TestConfigurator(unittest.TestCase):
             'PYTHONPATH': ':'.join(sys.path),
         }
         p = subprocess.Popen(
-            (script_path, '--app-dir', self.app_dir, 'myapp', 'myenv'),
+            (script_path, '--app-dir', self.app_dir, '--configs-dir', '.',
+             'myapp', 'myenv'),
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, env=env)
         out, err = p.communicate()


### PR DESCRIPTION
`configurator.py` uses `--configs-dir` in order to find config files. This option
has a default (https://github.com/yola/yoconfigurator/blob/992f5ac181fea2bb7b7bbf54c6785757f491df2a/bin/configurator.py#L60-L64).

On a local machine there won't be any config files in those directories for
configurator to read.

On a server (for example a ci box) there will be configs in these directories
which will be read by configurator. These configs will then change the output
of the `.json` file that is written by the tests and then fail the
`test_creates_a_config_that_looks_as_expected` test.

I don't know if this is the correct solution to fix this test failing on a ci box. Suggestions for a better solution is welcome.