### PR TITLE
bump version to 0.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-Dev
+0.5.0
 -----
 
 * Update to work with Python 2.7, 3.2, 3.3, 3.4, 3.5

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='engineers@yola.com',
     license='MIT (Expat)',
     url='https://github.com/yola/yoconfigurator',
-    version='0.4.6',
+    version='0.5.0',
     packages=find_packages(),
     scripts=['bin/configurator.py'],
     test_suite='yoconfigurator.tests',


### PR DESCRIPTION
Version 0.5.0 drops support for Python <= 2.6, add support for Python >= 3.2