### PR TITLE
join seeded_auth_token params as strings and then encode to bytes

### DIFF
--- a/yoconfigurator/credentials.py
+++ b/yoconfigurator/credentials.py
@@ -4,5 +4,6 @@ import hashlib
 def seeded_auth_token(client, service, seed):
     """Return an auth token based on the client+service+seed tuple."""
     hash_func = hashlib.md5()
-    hash_func.update(b','.join((client, service, seed)))
+    token = ','.join((client, service, seed)).encode('utf-8')
+    hash_func.update(token)
     return hash_func.hexdigest()

--- a/yoconfigurator/tests/test_credentials.py
+++ b/yoconfigurator/tests/test_credentials.py
@@ -5,5 +5,5 @@ from ..credentials import seeded_auth_token
 
 class TestSeededAuthToken(unittest.TestCase):
     def test_seeded_auth(self):
-        self.assertEqual(seeded_auth_token(b'foo', b'bar', b'baz'),
+        self.assertEqual(seeded_auth_token('foo', 'bar', 'baz'),
                          '5a9350198f854de4b2ab56f187f87707')


### PR DESCRIPTION
The params to seeded_auth_token should always be of type `str`
so they should be joined into another `str` object which is then encoded
to bytes before being passed to `update`